### PR TITLE
Use browser crypto when available

### DIFF
--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -2,8 +2,15 @@
 
 const asn1js = require("asn1js");
 const pkijs = require("pkijs");
-const WebCrypto = require("node-webcrypto-ossl");
-const webcrypto = new WebCrypto();
+
+let webcrypto;
+
+if ((typeof self !== "undefined") && "crypto" in self) {
+	webcrypto = self.crypto;
+} else {
+	const WebCrypto = require("node-webcrypto-ossl");
+	webcrypto = new WebCrypto();
+}
 
 const {
 	CryptoEngine,


### PR DESCRIPTION
This project can't currently work in a browser environment (or hybrid like Electron) because it depends on `node-webcrypto-ossl`. Since `node-webcrypto-ossl` is simply polyfilling WebCrypto from the browser anyway, this PR first checks if it's in a browser environment which has WebCrypto and if so uses that, otherwise it falls back to `node-webcrypto-ossl`.