### PR TITLE
Change most links to point to new org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/webauthn-open-source/fido2-lib.svg?branch=master)](https://travis-ci.org/webauthn-open-source/fido2-lib) [![Coverage Status](https://coveralls.io/repos/github/webauthn-open-source/fido2-lib/badge.svg?branch=master)](https://coveralls.io/github/webauthn-open-source/fido2-lib?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/webauthn-open-source/fido2-lib/badge.svg?targetFile=package.json)](https://snyk.io/test/github/webauthn-open-source/fido2-lib?targetFile=package.json)
+[![Build Status](https://travis-ci.org/apowers313/fido2-lib.svg?branch=master)](https://travis-ci.org/apowers313/fido2-lib) [![Coverage Status](https://coveralls.io/repos/github/apowers313/fido2-lib/badge.svg?branch=master)](https://coveralls.io/github/apowers313/fido2-lib?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/webauthn-open-source/fido2-lib/badge.svg?targetFile=package.json)](https://snyk.io/test/github/webauthn-open-source/fido2-lib?targetFile=package.json)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/apowers313/fido2-lib.svg?branch=master)](https://travis-ci.org/apowers313/fido2-lib) [![Coverage Status](https://coveralls.io/repos/github/apowers313/fido2-lib/badge.svg?branch=master)](https://coveralls.io/github/apowers313/fido2-lib?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/apowers313/fido2-lib/badge.svg?targetFile=package.json)](https://snyk.io/test/github/apowers313/fido2-lib?targetFile=package.json)
+[![Build Status](https://travis-ci.org/webauthn-open-source/fido2-lib.svg?branch=master)](https://travis-ci.org/webauthn-open-source/fido2-lib) [![Coverage Status](https://coveralls.io/repos/github/webauthn-open-source/fido2-lib/badge.svg?branch=master)](https://coveralls.io/github/webauthn-open-source/fido2-lib?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/webauthn-open-source/fido2-lib/badge.svg?targetFile=package.json)](https://snyk.io/test/github/webauthn-open-source/fido2-lib?targetFile=package.json)
 
 ## Install
 
@@ -12,16 +12,16 @@ A library for performing FIDO 2.0 / WebAuthn server functionality
 This library contains all the functionality necessary for implementing a full FIDO2 / WebAuthn server. It intentionally does not implement any kind of networking protocol (e.g. - REST endpoints) so that it can remain independent of any messaging protocols.
 
 There are four primary functions:
-1. [attestationOptions](https://apowers313.github.io/fido2-lib/Fido2Lib.html#attestationOptions) - creates the challenge that will be sent to the client (e.g. - browser) for the credential create call. Note that the library does not keep track of sessions or context, so the caller is expected to associate the resulting challenge with a session so that it can be appropriately matched with a response.
-2. [attestationResult](https://apowers313.github.io/fido2-lib/Fido2Lib.html#attestationResult) - parses and validates the response from the client
-3. [assertionOptions](https://apowers313.github.io/fido2-lib/Fido2Lib.html#assertionOptions) - creates the challenge that will be sent to the client for credential assertion.
-4. [assertionResult](https://apowers313.github.io/fido2-lib/Fido2Lib.html#assertionResult) - parses and validates the response from the client
+1. [attestationOptions](https://webauthn-open-source.github.io/fido2-lib/Fido2Lib.html#attestationOptions) - creates the challenge that will be sent to the client (e.g. - browser) for the credential create call. Note that the library does not keep track of sessions or context, so the caller is expected to associate the resulting challenge with a session so that it can be appropriately matched with a response.
+2. [attestationResult](https://webauthn-open-source.github.io/fido2-lib/Fido2Lib.html#attestationResult) - parses and validates the response from the client
+3. [assertionOptions](https://webauthn-open-source.github.io/fido2-lib/Fido2Lib.html#assertionOptions) - creates the challenge that will be sent to the client for credential assertion.
+4. [assertionResult](https://webauthn-open-source.github.io/fido2-lib/Fido2Lib.html#assertionResult) - parses and validates the response from the client
 
 There is also an extension point for adding new attestation formats.
 
-Full documentation can be found [here](https://apowers313.github.io/fido2-lib/).
+Full documentation can be found [here](https://webauthn-open-source.github.io/fido2-lib/).
 
-For working examples see [fido2-server-demo](https://github.com/apowers313/fido2-server-demo) and / or [webauthn.org](https://webauthn.org)
+For working examples see [fido2-server-demo](https://github.com/webauthn-open-source/fido2-server-demo) and / or [webauthn.org](https://webauthn.org)
 
 ## Features
 
@@ -106,7 +106,7 @@ var authnResult = await f2l.attestationResult(clientAssertionResponse, assertion
 // authentication complete!
 ```
 
-For a real-life example, refer to [component-fido2](https://github.com/apowers313/component-fido2).
+For a real-life example, refer to [component-fido2](https://github.com/webauthn-open-source/component-fido2).
 
 ## Sponsor
 Note that while I used to be Technical Director for FIDO Alliance (and I am currently the Technical Advisor for FIDO Alliance), THIS PROJECT IS NOT ENDORSED OR SPONSORED BY FIDO ALLIANCE.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "istanbul cover _mocha",
     "docs": "jsdoc -c ./.jsdoc-conf.json",
-    "publish-docs": "gh-pages --repo https://$GH_TOKEN@github.com/apowers313/fido2-lib.git --dist docs"
+    "publish-docs": "gh-pages --repo https://$GH_TOKEN@github.com/webauthn-open-source/fido2-lib.git --dist docs"
   },
   "keywords": [
     "webauthn",
@@ -21,10 +21,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apowers313/fido2-lib"
+    "url": "https://github.com/webauthn-open-source/fido2-lib"
   },
   "bugs": {
-    "url": "https://github.com/apowers313/fido2-lib/issues",
+    "url": "https://github.com/webauthn-open-source/fido2-lib/issues",
     "email": "apowers@ato.ms"
   },
   "devDependencies": {


### PR DESCRIPTION
While GitHub redirects some links after a repository is transferred, not all of them work and I think depending on redirects isn't the best idea. I changed the user part of most github urls - leaving travis and coveralls, since they aren't enabled for this org.
The links to documentation were broken, so now they should work again.