### PR TITLE
Update certUtils.js

### DIFF
--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -2,7 +2,15 @@
 
 const asn1js = require("asn1js");
 const pkijs = require("pkijs");
-const webcrypto = require("crypto").webcrypto;
+
+let webcrypto
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+if (NODE_MAJOR_VERSION >= 15) {
+	webcrypto = require("crypto").webcrypto;
+} else {
+	const { Crypto } = require("node-webcrypto-ossl");
+	webcrypto = new Crypto();
+}
 
 const {
 	CryptoEngine,


### PR DESCRIPTION
Reference Issue #66

This is a compromise, but there will still be problems in the npm install for newer node/npm versions.

It would actually be better to remove the userland webcrypto module and use office nodeJS API