### PR TITLE
Proper user type in PublicKeyCredentialCreationOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fido2-lib",
-	"version": "2.8.2",
+	"version": "2.8.3",
 	"description": "A library for performing FIDO 2.0 / WebAuthn functionality",
 	"main": "index.js",
 	"types": "./types/index.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ declare module "fido2-lib" {
 
   interface PublicKeyCredentialCreationOptions {
     rp: { name: string; id: string; icon?: string };
-    user: {};
+    user: { id: string, name: string, displayName: string };
     challenge: ArrayBuffer;
     pubKeyCredParams: Array<{ type: "public-key"; alg: number }>;
     timeout?: number;


### PR DESCRIPTION
As per [the docs](https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-user), `value’s name, displayName and id members are REQUIRED.`.

This also causes an error with TypeScript when trying to assign these values: 
![image](https://user-images.githubusercontent.com/48063901/167127026-70063c8b-e268-49a3-a984-f696b23db789.png)
