### PR TITLE
Reduce warnings in build process + Bump asn1js major

### DIFF
--- a/deno-lock.json
+++ b/deno-lock.json
@@ -161,7 +161,7 @@
   "https://deno.land/x/test_suite@0.16.1/describe.ts": "c0c944d8e4fba4c54f168ba8799aca4ffabe7cdecfac28c5dbaf0d1f8b345df1",
   "https://deno.land/x/test_suite@0.16.1/mod.ts": "16dd20330261d5de4a0b4f85676329eb77679649d01e6468898883e527c9e133",
   "https://deno.land/x/test_suite@0.16.1/test_suite.ts": "7854f0ab37d920355fe2e1a2c386f104601449eb93fcf537dafe30d6915a32d4",
-  "https://unpkg.com/asn1js@2.3.2/src/asn1.js?module": "600a03729e07075d7b3569f727a939c25e2f96c0fdb1f7bb3eb1c8f238549889",
+  "https://unpkg.com/asn1js@3.0.1/build/index.es.js?module": "d063863645b8e27b2f1acb9b9f0206f0eabccd07050e06d0ab9e787ae18bac51",
   "https://unpkg.com/bytestreamjs@1.0.29/src/bytestream.js?module": "1e496c8bb962f28663bf239e279a31aebdbb00d2fc4ed55472a1930dfcebedef",
   "https://unpkg.com/pkijs@2.1.60/src/AccessDescription.js": "e32ca8d49e0d3f499e81cb714e192a4ba7df5a5ffea58b26a34d1f7466f9e0e1",
   "https://unpkg.com/pkijs@2.1.60/src/Accuracy.js": "99da5d0b983e57d2163930c273b6c1cc43b1a96b4cb4eac567d610f3331cc223",
@@ -270,5 +270,6 @@
   "https://unpkg.com/pkijs@2.1.60/src/TimeStampResp.js": "c7e70ae469fdad7f629fc7e292c71197409315a1f0f5de43e7883176e106ae33",
   "https://unpkg.com/pkijs@2.1.60/src/common.js": "590814c0721507a8d661433b6368a98fd8665ea793b7bb5e68be87f73b80f610",
   "https://unpkg.com/pkijs@2.1.60/src/index.js": "6f06a1ce39e1af24976c2118ab957fa276facd6f23af42c8dbfcf54c0d863f2c",
+  "https://unpkg.com/pvtsutils@1.3.2/build/index.es.js?module": "82e3289330c5ab2b1485084ef8bc621329bf817126951252cb336e619e322ecb",
   "https://unpkg.com/pvutils@1.1.3/build/utils.es.js?module": "6def4dab26340f2056fde9711dbf595396b64d53c720268b9f9a73c46940206f"
 }

--- a/import_map.json
+++ b/import_map.json
@@ -3,7 +3,7 @@
         "tldts": "https://cdn.jsdelivr.net/npm/tldts@5.7.77/dist/index.esm.min.js",
         "punycode": "https://deno.land/x/punycode@v2.1.1/punycode.js",
         "jose": "https://deno.land/x/jose@v4.7.0/index.ts?module",
-        "asn1js": "https://unpkg.com/asn1js@2.3.2/src/asn1.js?module",
+        "asn1js": "https://unpkg.com/asn1js@3.0.1?module",
         "cbor-x": "https://deno.land/x/cbor@v1.2.1/index.js?module",
         "std/": "https://deno.land/std@0.135.0/",
         "url": "https://deno.land/std@0.135.0/node/url.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "fido2-lib",
-	"version": "3.0.0",
+	"version": "3.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "fido2-lib",
-			"version": "3.0.0",
+			"version": "3.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@hexagon/base64": "^1.0.19",
 				"@peculiar/webcrypto": "^1.3.3",
-				"asn1js": "^2.3.2",
+				"asn1js": "^3.0.2",
 				"cbor-x": "^1.2.1",
 				"jose": "^4.7.0",
 				"pkijs": "2.1.60",
@@ -612,6 +612,17 @@
 				"tslib": "^2.3.1"
 			}
 		},
+		"node_modules/@peculiar/asn1-schema/node_modules/asn1js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+			"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+			"dependencies": {
+				"pvutils": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@peculiar/json-schema": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
@@ -881,14 +892,16 @@
 			}
 		},
 		"node_modules/asn1js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
-			"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.2.tgz",
+			"integrity": "sha512-//N3TnnL56cdjM5OGXBRWQ7D7/L9taP8DDkIjbs/2RhyKaDyotuVg1jolTyKfw89beUKB5FLW7Y9CB8EVmeY9g==",
 			"dependencies": {
-				"pvutils": "^1.1.3"
+				"pvtsutils": "^1.3.2",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.4.0"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/assertion-error": {
@@ -4158,6 +4171,17 @@
 				"tslib": "^2.3.1"
 			}
 		},
+		"node_modules/webcrypto-core/node_modules/asn1js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+			"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+			"dependencies": {
+				"pvutils": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -4803,6 +4827,16 @@
 				"asn1js": "^2.3.1",
 				"pvtsutils": "^1.2.1",
 				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"asn1js": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+					"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+					"requires": {
+						"pvutils": "^1.1.3"
+					}
+				}
 			}
 		},
 		"@peculiar/json-schema": {
@@ -5020,11 +5054,13 @@
 			"dev": true
 		},
 		"asn1js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
-			"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.2.tgz",
+			"integrity": "sha512-//N3TnnL56cdjM5OGXBRWQ7D7/L9taP8DDkIjbs/2RhyKaDyotuVg1jolTyKfw89beUKB5FLW7Y9CB8EVmeY9g==",
 			"requires": {
-				"pvutils": "^1.1.3"
+				"pvtsutils": "^1.3.2",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.4.0"
 			}
 		},
 		"assertion-error": {
@@ -7457,6 +7493,16 @@
 				"asn1js": "^2.3.2",
 				"pvtsutils": "^1.2.2",
 				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"asn1js": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+					"integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+					"requires": {
+						"pvutils": "^1.1.3"
+					}
+				}
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fido2-lib",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "A library for performing FIDO 2.0 / WebAuthn functionality",
 	"type": "module",
 	"main": "dist/main.cjs",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
 		"sinon": "^13.0.2"
 	},
 	"dependencies": {
-		"@peculiar/webcrypto": "^1.3.3",
 		"@hexagon/base64": "^1.0.19",
-		"asn1js": "^2.3.2",
+		"@peculiar/webcrypto": "^1.3.3",
+		"asn1js": "^3.0.2",
 		"cbor-x": "^1.2.1",
 		"jose": "^4.7.0",
 		"pkijs": "2.1.60",
@@ -116,7 +116,10 @@
 			"sourceType": "module",
 			"ecmaVersion": 13
 		},
-		"ignorePatterns": ["dist/*","test/dist/*"],
+		"ignorePatterns": [
+			"dist/*",
+			"test/dist/*"
+		],
 		"overrides": [
 			{
 				"files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,65 @@
+const devExternals = [
+	"chai",
+	"chai-as-promised",
+	"sinon"
+];
+const externals = [
+	"@hexagon/base64",
+	"url",
+	"tldts",
+	"punycode",
+	"jose",
+	"pkijs",
+	"asn1js",
+	"cbor-x",
+	"crypto",
+	"@peculiar/webcrypto"
+];
+const tests = [
+	"test/certUtils.test.js",
+	"test/extAppId.test.js",
+	"test/ext.test.js",
+	"test/keyUtils.test.js",
+	"test/main.test.js",
+	"test/mds.test.js",
+	"test/parseAndroidSafetyNetAttestationData.test.js",
+	"test/parseAssertion.test.js",
+	"test/parseBadData.test.js",
+	"test/parseClientData.test.js",
+	"test/parseExpectations.test.js",
+	"test/parseNoneAttestationData.test.js",
+	"test/parsePackedAttestationData.test.js",
+	"test/parsePackedSelfAttestationData.test.js",
+	"test/parseTpmAttestationData.test.js",
+	"test/parseU2fAttestationData.test.js",
+	"test/response.test.js",
+	"test/toolbox.test.js",
+	"test/utils.test.js",
+	"test/validator.test.js"
+];
+
+function surpressWarnings (message, warn) {
+	if (message.code === 'CIRCULAR_DEPENDENCY') return
+	warn(message)
+}
+
 export default [
 	{
 		input: "lib/main.js",
+		external: [...externals],
 		output: {
 			file: "dist/main.cjs",
 			format: "cjs",
 		},
+		onwarn: surpressWarnings
 	},
 	{
-		input: [
-			"test/certUtils.test.js",
-			"test/extAppId.test.js",
-			"test/ext.test.js",
-			"test/keyUtils.test.js",
-			"test/main.test.js",
-			"test/mds.test.js",
-			"test/parseAndroidSafetyNetAttestationData.test.js",
-			"test/parseAssertion.test.js",
-			"test/parseBadData.test.js",
-			"test/parseClientData.test.js",
-			"test/parseExpectations.test.js",
-			"test/parseNoneAttestationData.test.js",
-			"test/parsePackedAttestationData.test.js",
-			"test/parsePackedSelfAttestationData.test.js",
-			"test/parseTpmAttestationData.test.js",
-			"test/parseU2fAttestationData.test.js",
-			"test/response.test.js",
-			"test/toolbox.test.js",
-			"test/utils.test.js",
-			"test/validator.test.js",
-		],
+		input: [...tests],
+		external: [...externals,...devExternals],
 		output: {
 			dir: "test/dist/",
-			entryFileName: "[name].js",
 			format: "cjs",
 		},
+		onwarn: surpressWarnings
 	},
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 const devExternals = [
 	"chai",
 	"chai-as-promised",
-	"sinon"
+	"sinon",
 ];
 const externals = [
 	"@hexagon/base64",
@@ -13,7 +13,7 @@ const externals = [
 	"asn1js",
 	"cbor-x",
 	"crypto",
-	"@peculiar/webcrypto"
+	"@peculiar/webcrypto",
 ];
 const tests = [
 	"test/certUtils.test.js",
@@ -35,12 +35,12 @@ const tests = [
 	"test/response.test.js",
 	"test/toolbox.test.js",
 	"test/utils.test.js",
-	"test/validator.test.js"
+	"test/validator.test.js",
 ];
 
-function surpressWarnings (message, warn) {
-	if (message.code === 'CIRCULAR_DEPENDENCY') return
-	warn(message)
+function surpressWarnings(message, warn) {
+	if (message.code === "CIRCULAR_DEPENDENCY") return;
+	warn(message);
 }
 
 export default [
@@ -51,7 +51,7 @@ export default [
 			file: "dist/main.cjs",
 			format: "cjs",
 		},
-		onwarn: surpressWarnings
+		onwarn: surpressWarnings,
 	},
 	{
 		input: [...tests],
@@ -60,6 +60,6 @@ export default [
 			dir: "test/dist/",
 			format: "cjs",
 		},
-		onwarn: surpressWarnings
+		onwarn: surpressWarnings,
 	},
 ];

--- a/test/extAppId.test.js
+++ b/test/extAppId.test.js
@@ -1,0 +1,6 @@
+// Testing lib
+import * as chai from "chai";
+
+describe("extAppId", function() {
+	it("works");
+});


### PR DESCRIPTION
* Fix rollup bundling warnings
* Add empty test in empty file extAppId.test.js, to not have warnings