### PR TITLE
Don't re-assign const

### DIFF
--- a/lib/keyUtils.js
+++ b/lib/keyUtils.js
@@ -488,7 +488,7 @@ class PublicKey {
 		if (this._original_pem && !forcedExport) {
 			return this._original_pem;
 		} else if (this.getKey()) {
-			const pemResult = abToPem("PUBLIC KEY",await tools.webcrypto.subtle.exportKey("spki", this.getKey()));
+			let pemResult = abToPem("PUBLIC KEY",await tools.webcrypto.subtle.exportKey("spki", this.getKey()));
 			
 			// Add trailing \n if missing (Deno only)
 			if (pemResult[pemResult.length - 1] !== "\n") {


### PR DESCRIPTION
Fix small syntax error introduced in deno compat