### PR TITLE
Fix, follow spec, response.userHandle allow null

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -371,7 +371,7 @@ async function parseAuthnrAssertionResponse(msg) {
 	}
 
 	let userHandle;
-	if (msg.response.userHandle !== undefined) {
+	if (msg.response.userHandle !== undefined && msg.response.userHandle !== null) {
 		userHandle = coerceToArrayBuffer(msg.response.userHandle, "response.userHandle");
 		if (userHandle.byteLength === 0) {
 			userHandle = undefined;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -220,7 +220,7 @@ function validateAssertionResponse() {
 
 	if (typeof req.response.userHandle !== "string" &&
 		!(req.response.userHandle instanceof ArrayBuffer) &&
-		req.response.userHandle !== undefined) {
+		req.response.userHandle !== undefined && req.response.userHandle !== null) {
 		throw new TypeError("expected 'response.userHandle' to be base64 String, ArrayBuffer, or undefined");
 	}
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -686,7 +686,7 @@ describe("Fido2Lib", function() {
 				response: {
 					clientDataJSON: h.lib.assertionResponse.response.clientDataJSON,
 					authenticatorData: h.lib.assertionResponse.response.authenticatorData,
-					signature: h.lib.assertionResponse.response.signature
+					signature: h.lib.assertionResponse.response.signature,
 				},
 			};
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -686,8 +686,35 @@ describe("Fido2Lib", function() {
 				response: {
 					clientDataJSON: h.lib.assertionResponse.response.clientDataJSON,
 					authenticatorData: h.lib.assertionResponse.response.authenticatorData,
+					signature: h.lib.assertionResponse.response.signature
+				},
+			};
+
+			return serv.assertionResult(assertionResponse, expectations).then(
+				(res) => {
+					assert.instanceOf(res, Fido2AssertionResult);
+					return res;
+				},
+			);
+		});
+
+		it("valid assertion with null userHandle", function() {
+			const expectations = {
+				challenge: "eaTyUNnyPDDdK8SNEgTEUvz1Q8dylkjjTimYd5X7QAo-F8_Z1lsJi3BilUpFZHkICNDWY8r9ivnTgW7-XZC3qQ",
+				origin: "https://localhost:8443",
+				factor: "either",
+				publicKey: h.lib.assnPublicKey,
+				prevCounter: 362,
+				userHandle: null,
+			};
+
+			const assertionResponse = {
+				rawId: h.lib.assertionResponse.rawId,
+				response: {
+					clientDataJSON: h.lib.assertionResponse.response.clientDataJSON,
+					authenticatorData: h.lib.assertionResponse.response.authenticatorData,
 					signature: h.lib.assertionResponse.response.signature,
-					// userHandle: h.lib.assertionResponse.response.userHandle
+					userHandle: null,
 				},
 			};
 


### PR DESCRIPTION
# What
Fixes https://github.com/webauthn-open-source/fido2-lib/issues/113

# Changes
- Allow null in userHandle, and fixed regressions
- Added a test with null in userHandle