### PR TITLE
Update main.cjs to fix the issue#123, Array.prototype methods cause validation error in the expected transports[<method>] to be 'string'

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -2099,7 +2099,7 @@ async function validateTransports() {
 		throw new Error("expected transports to be 'null' or 'array<string>'");
 	}
 
-	for (const index in transports) {
+	for (const index of transports) {
 		if (typeof transports[index] !== "string") {
 			throw new Error("expected transports[" + index + "] to be 'string'");
 		}

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -2099,7 +2099,7 @@ async function validateTransports() {
 		throw new Error("expected transports to be 'null' or 'array<string>'");
 	}
 
-	for (const index of transports) {
+	for (const index in transports) {
 		if (typeof transports[index] !== "string") {
 			throw new Error("expected transports[" + index + "] to be 'string'");
 		}

--- a/dist/main.js
+++ b/dist/main.js
@@ -42932,7 +42932,7 @@ async function validateExpectations() {
             if (!Array.isArray(allowCredentials)) {
                 throw new Error("expected allowCredentials to be null or array");
             } else {
-                for(const index in allowCredentials){
+                for(const index of allowCredentials){
                     if (typeof allowCredentials[index].id === "string") {
                         allowCredentials[index].id = coerceToArrayBuffer(allowCredentials[index].id, "allowCredentials[" + index + "].id");
                     }
@@ -43019,7 +43019,7 @@ function parseExpectations(exp) {
         if (allowCredentials !== null && !Array.isArray(allowCredentials)) {
             throw new TypeError("expected 'allowCredentials' to be null or array, got " + typeof allowCredentials);
         }
-        for(const index in allowCredentials){
+        for(const index of allowCredentials){
             if (allowCredentials[index].id != null) {
                 allowCredentials[index].id = coerceToArrayBuffer(allowCredentials[index].id, "allowCredentials[" + index + "].id");
             }
@@ -43762,7 +43762,7 @@ async function validateTransports() {
     if (transports != null && !Array.isArray(transports)) {
         throw new Error("expected transports to be 'null' or 'array<string>'");
     }
-    for(const index in transports){
+    for(const index of transports){
         if (typeof transports[index] !== "string") {
             throw new Error("expected transports[" + index + "] to be 'string'");
         }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -107,7 +107,7 @@ function parseExpectations(exp) {
 			);
 		}
 
-		for (const index in allowCredentials) {
+		for (const index of allowCredentials) {
 			if (allowCredentials[index].id != null) {
 				allowCredentials[index].id = coerceToArrayBuffer(
 					allowCredentials[index].id,

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -249,7 +249,7 @@ async function validateTransports() {
 		throw new Error("expected transports to be 'null' or 'array<string>'");
 	}
 
-	for (const index in transports) {
+	for (const index of transports) {
 		if (typeof transports[index] !== "string") {
 			throw new Error("expected transports[" + index + "] to be 'string'");
 		}


### PR DESCRIPTION
Fix for Array.prototype methods cause validation error in the expected transports[<method>] to be 'string' #123

use 'of' instead of 'in' ,because 'in' iterates over all enumerable property keys of an object * including the method cause invalid validation error, "of" only iterates through the values of objects.