### PR TITLE
Add fixes for getIssuer and getSerial (#15)

### DIFF
--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -81,8 +81,16 @@ class Certificate {
 		return this.searchForCommonName(this._cert.issuer.typesAndValues);
 	}
 
-	getSerial() {
-		return this._cert.serialNumber.valueBlock.toString();
+	getSerial(compatability) {
+		if (compatability === undefined) {
+			console.warn('[DEPRECATION WARNING] Please use getSerial("v1") or getSerial("v2").');
+		} else if (compatability === 'v1') {
+			console.warn('[DEPRECATION WARNING] Please migrate to getSerial("v2") which will return just the serial number.');
+		}
+
+		return (compatability === 'v2') 
+			? this._cert.serialNumber.valueBlock.toString()
+			: this.getCommonName(this._cert.serialNumber.valueBlock);
 	}
 
 	getVersion() {

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -38,18 +38,10 @@ class Certificate {
 
 	static #searchForCommonName(attributes) {
 		const X509_COMMON_NAME_KEY = "2.5.4.3";
-
-		let commonName = ""; // Default in case no subject is found
-
 		// Search the attributes for the common name of the certificate
-		for (let index = 0; index < attributes.length; index++) {
-			const attribute = attributes[index];
-			if (attribute.type === X509_COMMON_NAME_KEY) {
-				commonName = attribute.value.valueBlock.value;
-				break;
-			}
-		}
-		return commonName;
+		const commonNameAttr = attributes.find((attr) => attr.type == X509_COMMON_NAME_KEY);
+		// Return empty string if not found
+		return commonNameAttr ? commonNameAttr.value.valueBlock.value : "";
 	}
 
 	verify() {

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -39,9 +39,13 @@ class Certificate {
 	searchForCommonName(attributes) {
 		const X509_COMMON_NAME_KEY = "2.5.4.3";
 		// Search the attributes for the common name of the certificate
-		const commonNameAttr = attributes.find((attr) => attr.type == X509_COMMON_NAME_KEY);
+		for (const attr of attributes) {
+			if (attr.type === X509_COMMON_NAME_KEY) {
+				return attr.value.valueBlock.value;
+			}
+		}
 		// Return empty string if not found
-		return commonNameAttr ? commonNameAttr.value.valueBlock.value : "";
+		return "";
 	}
 
 	verify() {

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -81,14 +81,14 @@ class Certificate {
 		return this.searchForCommonName(this._cert.issuer.typesAndValues);
 	}
 
-	getSerial(compatability) {
-		if (compatability === undefined) {
-			console.warn("[DEPRECATION WARNING] Please use getSerial(\"v1\") or getSerial(\"v2\").");
-		} else if (compatability === "v1") {
+	getSerial(compatibility) {
+		if (compatibility === undefined) {
+			console.warn("[DEPRECATION WARNING] Please use getSerial(\"v2\").");
+		} else if (compatibility === "v1") {
 			console.warn("[DEPRECATION WARNING] Please migrate to getSerial(\"v2\") which will return just the serial number.");
 		}
 
-		return (compatability === "v2") 
+		return (compatibility === "v2") 
 			? this._cert.serialNumber.valueBlock.toString()
 			: this.getCommonName(this._cert.serialNumber.valueBlock);
 	}

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -83,12 +83,12 @@ class Certificate {
 
 	getSerial(compatability) {
 		if (compatability === undefined) {
-			console.warn('[DEPRECATION WARNING] Please use getSerial("v1") or getSerial("v2").');
-		} else if (compatability === 'v1') {
-			console.warn('[DEPRECATION WARNING] Please migrate to getSerial("v2") which will return just the serial number.');
+			console.warn("[DEPRECATION WARNING] Please use getSerial(\"v1\") or getSerial(\"v2\").");
+		} else if (compatability === "v1") {
+			console.warn("[DEPRECATION WARNING] Please migrate to getSerial(\"v2\") which will return just the serial number.");
 		}
 
-		return (compatability === 'v2') 
+		return (compatability === "v2") 
 			? this._cert.serialNumber.valueBlock.toString()
 			: this.getCommonName(this._cert.serialNumber.valueBlock);
 	}

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -33,10 +33,10 @@ class Certificate {
 	}
 
 	getCommonName() {
-		return Certificate.#searchForCommonName(this._cert.subject.typesAndValues);
+		return this.searchForCommonName(this._cert.subject.typesAndValues);
 	}
 
-	static #searchForCommonName(attributes) {
+	searchForCommonName(attributes) {
 		const X509_COMMON_NAME_KEY = "2.5.4.3";
 		// Search the attributes for the common name of the certificate
 		const commonNameAttr = attributes.find((attr) => attr.type == X509_COMMON_NAME_KEY);
@@ -74,7 +74,7 @@ class Certificate {
 	}
 
 	getIssuer() {
-		return Certificate.#searchForCommonName(this._cert.issuer.typesAndValues);
+		return this.searchForCommonName(this._cert.issuer.typesAndValues);
 	}
 
 	getSerial() {

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -90,7 +90,7 @@ class Certificate {
 
 		return (compatibility === "v2") 
 			? this._cert.serialNumber.valueBlock.toString()
-			: this.getCommonName(this._cert.serialNumber.valueBlock);
+			: this.getCommonName();
 	}
 
 	getVersion() {

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -487,7 +487,7 @@ const certMap = new Map();
 class CertManager {
 	static addCert(certBuf) {
 		const cert = new Certificate(certBuf);
-		const serial = cert.getIssuer();
+		const serial = cert.getCommonName();
 		certMap.set(serial, cert);
 
 		return true;

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -33,14 +33,17 @@ class Certificate {
 	}
 
 	getCommonName() {
+		return Certificate.#searchForCommonName(this._cert.subject.typesAndValues);
+	}
+
+	static #searchForCommonName(attributes) {
 		const X509_COMMON_NAME_KEY = "2.5.4.3";
 
 		let commonName = ""; // Default in case no subject is found
 
-		// Search the subject's attributes for the common name of the certificate
-		const subjectAttributes = this._cert.subject.typesAndValues;
-		for (let index = 0; index < subjectAttributes.length; index++) {
-			const attribute = subjectAttributes[index];
+		// Search the attributes for the common name of the certificate
+		for (let index = 0; index < attributes.length; index++) {
+			const attribute = attributes[index];
 			if (attribute.type === X509_COMMON_NAME_KEY) {
 				commonName = attribute.value.valueBlock.value;
 				break;
@@ -79,11 +82,11 @@ class Certificate {
 	}
 
 	getIssuer() {
-		return this._cert.issuer.typesAndValues[0].value.valueBlock.value;
+		return Certificate.#searchForCommonName(this._cert.issuer.typesAndValues);
 	}
 
 	getSerial() {
-		return this._cert.subject.typesAndValues[0].value.valueBlock.value;
+		return this._cert.serialNumber.valueBlock.toString();
 	}
 
 	getVersion() {
@@ -480,7 +483,7 @@ const certMap = new Map();
 class CertManager {
 	static addCert(certBuf) {
 		const cert = new Certificate(certBuf);
-		const serial = cert.getSerial();
+		const serial = cert.getIssuer();
 		certMap.set(serial, cert);
 
 		return true;

--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -49,8 +49,8 @@ class Certificate {
 	}
 
 	verify() {
-		const issuerSerial = this.getIssuer();
-		const issuerCert = CertManager.getCertBySerial(issuerSerial);
+		const issuerCommonName = this.getIssuer();
+		const issuerCert = CertManager.getCertByCommonName(issuerCommonName);
 		const _issuerCert = issuerCert ? issuerCert._cert : undefined;
 		return this._cert.verify(_issuerCert)
 			.catch((err) => {
@@ -487,8 +487,8 @@ const certMap = new Map();
 class CertManager {
 	static addCert(certBuf) {
 		const cert = new Certificate(certBuf);
-		const serial = cert.getCommonName();
-		certMap.set(serial, cert);
+		const commonName = cert.getCommonName();
+		certMap.set(commonName, cert);
 
 		return true;
 	}
@@ -498,7 +498,12 @@ class CertManager {
 	}
 
 	static getCertBySerial(serial) {
+		console.warn("[DEPRECATION WARNING] Please use CertManager.getCertByCommonName(commonName).");
 		return certMap.get(serial);
+	}
+
+	static getCertByCommonName(commonName) {
+		return certMap.get(commonName);
 	}
 
 	static removeAll() {

--- a/test/certUtils.test.js
+++ b/test/certUtils.test.js
@@ -116,12 +116,12 @@ describe("cert utils", function() {
 		describe("getSerial", function() {
 			it("returns correct serial for attestation", function() {
 				const cert = new Certificate(h.certs.yubiKeyAttestation);
-				const serial = cert.getSerial();
+				const serial = cert.getSerial("v2");
 				assert.strictEqual(serial, "1432534688");
 			});
 			it("returns correct serial for root", function() {
 				const cert = new Certificate(h.certs.yubicoRoot);
-				const serial = cert.getSerial();
+				const serial = cert.getSerial("v2");
 				assert.strictEqual(
 					serial,
 					"457200631",

--- a/test/certUtils.test.js
+++ b/test/certUtils.test.js
@@ -117,14 +117,14 @@ describe("cert utils", function() {
 			it("returns correct serial for attestation", function() {
 				const cert = new Certificate(h.certs.yubiKeyAttestation);
 				const serial = cert.getSerial();
-				assert.strictEqual(serial, "Yubico U2F EE Serial 1432534688");
+				assert.strictEqual(serial, "1432534688");
 			});
 			it("returns correct serial for root", function() {
 				const cert = new Certificate(h.certs.yubicoRoot);
 				const serial = cert.getSerial();
 				assert.strictEqual(
 					serial,
-					"Yubico U2F Root CA Serial 457200631",
+					"457200631",
 				);
 			});
 		});


### PR DESCRIPTION
Hi there, I know this is a pretty old issue so I figured I'd take it up. This is my first contribution to an open source library. :-)

I've added fixes for the getIssuer and getSerial functions in certUtils as requested in https://github.com/webauthn-open-source/fido2-lib/issues/15. It'll no longer be necessary to index directly into `typesAndValues`. Please let me know if there's anything else that I'm missing!