### PR TITLE
Fix/browser support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 import * as utils from "./utils.js";
+import { ready } from "./toolbox.js";
 
 import { Fido2AssertionResult, Fido2AttestationResult, Fido2Result } from "./response.js";
 
@@ -166,6 +167,7 @@ class Fido2Lib {
 	 * @see  MdsCollection
 	 */
 	static async addMdsCollection(mdsCollection) {
+		await ready;
 		if (!(mdsCollection instanceof MdsCollection)) {
 			throw new Error(
 				"expected 'mdsCollection' to be instance of MdsCollection, got: " +
@@ -386,6 +388,7 @@ class Fido2Lib {
 	 * @private
 	 */
 	static async validateAttestation() {
+		await ready;
 		const fmt = this.authnrData.get("fmt");
 
 		// validate input
@@ -542,6 +545,7 @@ class Fido2Lib {
 	 * @throws {Error} If parsing or validation fails
 	 */
 	async attestationResult(res, expected) {
+		await ready;
 		expected.flags = factorToFlags(expected.factor, ["AT"]);
 		delete expected.factor;
 		return await Fido2AttestationResult.create(res, expected);
@@ -574,6 +578,7 @@ class Fido2Lib {
 	 */
 	// deno-lint-ignore require-await
 	async assertionResult(res, expected) {
+		await ready;
 		expected.flags = factorToFlags(expected.factor, []);
 		delete expected.factor;
 		return Fido2AssertionResult.create(res, expected);
@@ -594,6 +599,7 @@ class Fido2Lib {
 	 * @returns {Promise<PublicKeyCredentialCreationOptions>} The options for creating calling `navigator.credentials.create()`
 	 */
 	async attestationOptions(opts) {
+		await ready;
 		opts = opts || {};
 
 		// The object being returned is described here:
@@ -714,6 +720,7 @@ class Fido2Lib {
 	 * @returns {Promise<PublicKeyCredentialRequestOptions>} The options to be passed to `navigator.credentials.get()`
 	 */
 	async assertionOptions(opts) {
+		await ready;
 		opts = opts || {};
 
 		// https://w3c.github.io/webauthn/#dictdef-publickeycredentialcreationoptions

--- a/lib/toolbox.js
+++ b/lib/toolbox.js
@@ -18,24 +18,41 @@ import base64 from "@hexagon/base64";
 import { Certificate } from "./certUtils.js";
 import { PublicKey } from "./keyUtils.js";
 
-// Import webcrypto
-import * as platformCrypto from "crypto";
-import * as peculiarCrypto from "@peculiar/webcrypto";
-let webcrypto;
-if ((typeof self !== "undefined") && "crypto" in self) {
-	// Always use crypto if available natively (browser / Deno)
-	webcrypto = self.crypto;
 
-} else {
-	// Always use node webcrypto if available ( >= 16.0 )
-	if(platformCrypto && platformCrypto.webcrypto) {
-		webcrypto = platformCrypto.webcrypto;
-
-	} else {
-		// Fallback to @peculiar/webcrypto
-		webcrypto = new peculiarCrypto.Crypto();
-	}
+function isNode() {
+	// see: https://stackoverflow.com/a/35813135
+	// and https://github.com/contentful/contentful.js/issues/422#issuecomment-1054400365
+	return typeof process !== "undefined" &&
+		!process.browser &&
+		!!process.versions && 
+		!!process.versions.node;
 }
+
+// Import webcrypto
+let webcrypto;
+const __setWebCrypto = async () => {
+	if (isNode()) {
+		// Always use node webcrypto if available ( >= 16.0 )
+		return import("crypto").then(m => {
+			webcrypto = m.webcrypto;
+		}).catch(() => {
+			// Fallback to @peculiar/webcrypto
+			return import("@peculiar/webcrypto").then(m => {
+				webcrypto = new m.Crypto();
+			});
+		});
+	}
+	if ((typeof self !== "undefined") && "crypto" in self) {
+		// Always use crypto if available natively (browser / Deno)
+		webcrypto = self.crypto;
+		return;
+	}
+	throw new Error("WebCrypto implementation not available. " +
+		"Install optional dependecies to include @peculiar/webcrypto or " +
+		"update your Node.js (later than 16).");
+};
+let ready = __setWebCrypto();
+
 
 // Set up pkijs
 const pkijs = {
@@ -46,15 +63,17 @@ const pkijs = {
 	CertificateChainValidationEngine,
 	PublicKeyInfo,
 };
-pkijs.setEngine(
-	"newEngine",
-	webcrypto,
-	new pkijs.CryptoEngine({
-		name: "",
-		crypto: webcrypto,
-		subtle: webcrypto.subtle,
-	}),
-);
+ready = ready.then(() => {
+	pkijs.setEngine(
+		"newEngine",
+		webcrypto,
+		new pkijs.CryptoEngine({
+			name: "",
+			crypto: webcrypto,
+			subtle: webcrypto.subtle,
+		}),
+	);
+});
 
 function extractBigNum(fullArray, start, end, expectedLength) {
 	let num = fullArray.slice(start, end);
@@ -363,5 +382,6 @@ export {
 	pkijs,
 	randomValues,
 	verifySignature,
-	webcrypto
+	webcrypto,
+	ready
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
 	"name": "fido2-lib",
-	"version": "3.4.1",
+	"version": "3.4.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "fido2-lib",
-			"version": "3.4.1",
+			"version": "3.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@hexagon/base64": "~1.1.26",
-				"@peculiar/webcrypto": "~1.4.3",
 				"asn1js": "~3.0.2",
 				"cbor-x": "~1.5.3",
 				"jose": "^4.14.4",
@@ -31,6 +30,9 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"optionalDependencies": {
+				"@peculiar/webcrypto": "~1.4.3"
 			}
 		},
 		"node_modules/@babel/parser": {
@@ -51,7 +53,7 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+"node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz",
 			"integrity": "sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==",
@@ -320,6 +322,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
 			"integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+			"optional": true,
 			"dependencies": {
 				"asn1js": "^3.0.5",
 				"pvtsutils": "^1.3.2",
@@ -330,6 +333,7 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
 			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+			"optional": true,
 			"dependencies": {
 				"tslib": "^2.0.0"
 			},
@@ -341,6 +345,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
 			"integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+			"optional": true,
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
@@ -1357,7 +1362,7 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"node_modules/fsevents": {
+"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
@@ -2946,6 +2951,7 @@
 			"version": "1.7.7",
 			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
 			"integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+			"optional": true,
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
@@ -3106,7 +3112,7 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@cbor-extract/cbor-extract-darwin-arm64": {
+"@cbor-extract/cbor-extract-darwin-arm64": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz",
 			"integrity": "sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==",
@@ -3292,6 +3298,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
 			"integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+			"optional": true,
 			"requires": {
 				"asn1js": "^3.0.5",
 				"pvtsutils": "^1.3.2",
@@ -3302,6 +3309,7 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
 			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+			"optional": true,
 			"requires": {
 				"tslib": "^2.0.0"
 			}
@@ -3310,6 +3318,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
 			"integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+			"optional": true,
 			"requires": {
 				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
@@ -4082,7 +4091,7 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"fsevents": {
+"fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
@@ -5254,6 +5263,7 @@
 			"version": "1.7.7",
 			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
 			"integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+			"optional": true,
 			"requires": {
 				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -49,12 +49,14 @@
 	},
 	"dependencies": {
 		"@hexagon/base64": "~1.1.26",
-		"@peculiar/webcrypto": "~1.4.3",
 		"asn1js": "~3.0.2",
 		"cbor-x": "~1.5.3",
 		"jose": "^4.14.4",
 		"pkijs": "~3.0.15",
 		"tldts": "~6.0.5"
+	},
+	"optionalDependencies": {
+		"@peculiar/webcrypto": "~1.4.3"
 	},
 	"eslintConfig": {
 		"root": true,

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,8 +1,9 @@
 /// <reference types="node" />
 
-import {JWTPayload} from "jose/dist/types/types";
-
 declare module "fido2-lib" {
+  // Type imports in ambient module should use import(),
+  // see https://stackoverflow.com/questions/39040108
+  type JWTPayload = import("jose/dist/types/types").JWTPayload;
 
   class MdsEntry{
     constructor(mdsEntry: Object, tocEntry: Object)


### PR DESCRIPTION
Allows one to use `fido2-lib` in the browser.

This was theoretically possible also beforehand, as the groundwork was there, but browser packagers made a jumble because of the conflicts with the 'crypto' global - so adding an explicit check and doing dynamic imports was the way to go.

Since the imports are made dynamic, it means they're promised, and thus a module-level variable `ready` was introduced which should be `await`-ed before any invocation of the WebCrypto API.

I assumed any use of WebCrypto is promised anyway, so waiting for `ready` is only relevant in the async APIs in the main module - but I haven't checked this and I advise someone with deeper familiarity with the package review this.
Also, I have not tested with Node engine version <16.