### PR TITLE
Fixed an error in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ const f2l = new Fido2Lib({
 ``` js
 const registrationOptions = await f2l.attestationOptions();
 
-// make sure to add registrationOptions.user.id
+// make sure to add registrationOptions.user.id and registrationOptions.user.name
 // save the challenge in the session information...
 // send registrationOptions to client and pass them in to `navigator.credentials.create()`...
 // get response back from client (clientAttestationResponse)


### PR DESCRIPTION
In the latest version of Chrome, navigator.credentials.create() requires "registrationOptions.user.id" in addition to the "registrationOptions.user.name"
![image](https://github.com/webauthn-open-source/fido2-lib/assets/143427814/d04127ab-abb0-428f-bf2c-7b18e075cdb0)
